### PR TITLE
Removed `(use 'lexicase-redux.core)` from instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is looking like it'll end up as a bunch of interactive design spikes.
 
 1. navigate to project directory
 2. `lein repl`
-3. `(use 'lexicase-redux.core)`
 4. `(use 'midje.repl)`
 5. `(autotest)`
 6. edit the source code in `src/lexicase_redux/core.clj`


### PR DESCRIPTION
I don't think this is necessary if we have the `project.clj` file set up correctly and have the standard directory structure. And when I tried to do it by hand it barfed errors at me. So I propose we remove it.

I made a pull request instead of just removing it directly because I wasn't sure if you had found you needed that line on your end for some reason.
